### PR TITLE
fix ld.lld duplicate symbols build error.

### DIFF
--- a/drivers/media/platform/mtk-vcu/Makefile
+++ b/drivers/media/platform/mtk-vcu/Makefile
@@ -1,7 +1,8 @@
 subdir-ccflags-y += -Werror
 ccflags-y += -I$(srctree)/drivers/misc/mediatek/smi
 ccflags-y += -I$(srctree)/drivers/misc/mediatek/cmdq
-mtk-vcu-y += mtk_vcu.o \
+mtk-vcu-y += mtk_vcu.o
+#mtk-vcu-y += mtk_vcu.o \
 	mtk_vcodec_mem.o \
 
 obj-$(CONFIG_VIDEO_MEDIATEK_VCU) += mtk-vcu.o mtk_vcodec_mem.o


### PR DESCRIPTION
ld.lld: error: duplicate symbol: vcu_buffer_cache_sync
defined at mtk_vcodec_mem.c:398

same duplicate symbol error appears for all structs and functions in mtk_vcodec_mem.c

not including mtk_vcodec_mem.o results in a successful working build

error happened compiling with proton clang from elixir sources.

[error-extracted.log](https://github.com/SakilMondal/android_kernel_oneplus_denniz/files/10035129/error-extracted.log)
